### PR TITLE
Constructor Call Correction

### DIFF
--- a/contract/src/main.rs
+++ b/contract/src/main.rs
@@ -223,14 +223,7 @@ pub extern "C" fn call() {
         Some("bridge_pool_access_uref".to_string()),
     );
 
-    let package_hash: ContractPackageHash = ContractPackageHash::new(
-        runtime::get_key("contract_package_hash")
-            .unwrap_or_revert()
-            .into_hash()
-            .unwrap_or_revert(),
-    );
-
-    let package_hash_key: Key = package_hash.into();
+    let package_hash_key: Key = stored_contract_hash.into();
 
     let _: () = runtime::call_contract(
         stored_contract_hash,


### PR DESCRIPTION
In the call to the `constructor` which initiates the bridge contract, the contract was previously attempting to run `runtime::get_key` against the user's context, which does not have a package hash at the time of the get_key call. Removed this bit of code and adjusted the runtime argument sent to the `constructor` to use the declared name of the package hash, `stored_contract_hash`.
